### PR TITLE
Purge igv-widgets + data-modal; upgrade to Bootstrap 5 + infinite-table

### DIFF
--- a/css/widgets.css
+++ b/css/widgets.css
@@ -1,0 +1,282 @@
+/* Extracted from igv-widgets v1.5.4 embedCSS.js */
+.igv-widgets-alert-dialog-container {
+  box-sizing: content-box;
+  position: absolute;
+  z-index: 2048;
+  top: 50%;
+  left: 50%;
+  width: 400px;
+  height: 200px;
+  border-color: #7F7F7F;
+  border-radius: 4px;
+  border-style: solid;
+  border-width: thin;
+  outline: none;
+  font-family: \"Open Sans\", sans-serif;
+  font-size: 15px;
+  font-weight: 400;
+  background-color: white;
+  display: flex;
+  flex-flow: column;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+  align-items: center; }
+  .igv-widgets-alert-dialog-container > div:first-child {
+    display: flex;
+    flex-flow: row;
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    align-items: center;
+    width: 100%;
+    height: 24px;
+    cursor: move;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+    border-bottom-color: #7F7F7F;
+    border-bottom-style: solid;
+    border-bottom-width: thin;
+    background-color: #eee; }
+    .igv-widgets-alert-dialog-container > div:first-child div:first-child {
+      padding-left: 8px; }
+  .igv-widgets-alert-dialog-container #igv-widgets-alert-dialog-body {
+    color: #373737;
+    width: 100%;
+    height: calc(100% - 24px - 64px);
+    overflow-y: scroll; }
+    .igv-widgets-alert-dialog-container #igv-widgets-alert-dialog-body #igv-widgets-alert-dialog-body-copy {
+      cursor: pointer;
+      margin: 16px;
+      width: auto;
+      height: auto;
+      overflow-wrap: break-word;
+      word-break: break-word;
+      background-color: white;
+      border: unset; }
+  .igv-widgets-alert-dialog-container > div:last-child {
+    width: 100%;
+    margin-bottom: 10px;
+    background-color: white;
+    display: flex;
+    flex-flow: row;
+    flex-wrap: nowrap;
+    justify-content: center;
+    align-items: center; }
+    .igv-widgets-alert-dialog-container > div:last-child div {
+      margin: unset;
+      width: 40px;
+      height: 30px;
+      line-height: 30px;
+      text-align: center;
+      color: white;
+      font-family: \"Open Sans\", sans-serif;
+      font-size: small;
+      font-weight: 400;
+      border-color: #2B81AF;
+      border-style: solid;
+      border-width: thin;
+      border-radius: 4px;
+      background-color: #2B81AF; }
+    .igv-widgets-alert-dialog-container > div:last-child div:hover {
+      cursor: pointer;
+      border-color: #25597f;
+      background-color: #25597f; }
+
+.igv-file-load-widget-container {
+  position: relative;
+  border-color: transparent;
+  width: 100%;
+  color: #7F7F7F;
+  font-family: \"Open Sans\", sans-serif;
+  font-size: 0.875rem;
+  font-weight: 200;
+  border-style: solid;
+  border-width: thin;
+  background-color: white;
+  display: flex;
+  flex-flow: column;
+  flex-wrap: nowrap;
+  justify-content: flex-start;
+  align-items: center; }
+  .igv-file-load-widget-container .igv-file-load-widget-header {
+    width: 100%;
+    height: 24px;
+    background-color: #bfbfbf;
+    display: flex;
+    flex-flow: row;
+    flex-wrap: nowrap;
+    justify-content: flex-end;
+    align-items: center; }
+    .igv-file-load-widget-container .igv-file-load-widget-header div {
+      height: 24px;
+      width: 16px;
+      margin-right: 6px;
+      text-align: center;
+      line-height: 24px;
+      color: #373737; }
+    .igv-file-load-widget-container .igv-file-load-widget-header div:hover {
+      cursor: pointer; }
+  .igv-file-load-widget-container .igv-flw-input-container {
+    width: 95%;
+    margin-top: 24px;
+    margin-bottom: 0;
+    display: flex;
+    flex-flow: column;
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    align-items: center; }
+    .igv-file-load-widget-container .igv-flw-input-container .igv-flw-input-row {
+      height: 36px;
+      width: 100%;
+      margin-top: 8px;
+      padding-top: 4px;
+      padding-bottom: 4px;
+      display: flex;
+      flex-flow: row;
+      flex-wrap: nowrap;
+      justify-content: flex-start;
+      align-items: center;
+      border-color: white;
+      border-style: solid;
+      border-width: thin;
+      border-radius: calc(2 * 2px); }
+      .igv-file-load-widget-container .igv-flw-input-container .igv-flw-input-row .igv-flw-input-label {
+        color: #6c757c;
+        font-weight: 400;
+        width: 136px;
+        height: 36px;
+        line-height: 36px;
+        text-align: left; }
+      .igv-file-load-widget-container .igv-flw-input-container .igv-flw-input-row input {
+        display: block;
+        height: 100%;
+        width: 100%;
+        padding-left: 4px;
+        color: #373737;
+        font-size: 0.875rem;
+        font-family: \"Open Sans\", sans-serif;
+        font-weight: 400;
+        text-align: left;
+        outline: none;
+        border-style: solid;
+        border-width: thin;
+        border-color: #dee2e6;
+        border-radius: .25rem;
+        background-color: white; }
+      .igv-file-load-widget-container .igv-flw-input-container .igv-flw-input-row input {
+        height: calc(36px - 12px); }
+      .igv-file-load-widget-container .igv-flw-input-container .igv-flw-input-row .igv-flw-file-chooser-container {
+        display: flex;
+        flex-flow: row;
+        justify-content: center;
+        align-items: center;
+        width: 130px;
+        height: calc(36px - 8px);
+        border-color: #6c757c;
+        border-style: solid;
+        border-width: thin;
+        border-radius: calc(2 * 2px);
+        background-color: white; }
+        .igv-file-load-widget-container .igv-flw-input-container .igv-flw-input-row .igv-flw-file-chooser-container label {
+          display: block;
+          margin: unset; }
+        .igv-file-load-widget-container .igv-flw-input-container .igv-flw-input-row .igv-flw-file-chooser-container label.igv-flw-label-color {
+          color: #6c757c; }
+        .igv-file-load-widget-container .igv-flw-input-container .igv-flw-input-row .igv-flw-file-chooser-container label.igv-flw-label-color-hover {
+          cursor: pointer; }
+        .igv-file-load-widget-container .igv-flw-input-container .igv-flw-input-row .igv-flw-file-chooser-container input.igv-flw-file-chooser-input {
+          width: 0.1px;
+          height: 0.1px;
+          opacity: 0;
+          overflow: hidden;
+          position: absolute;
+          z-index: -1; }
+      .igv-file-load-widget-container .igv-flw-input-container .igv-flw-input-row .igv-flw-file-chooser-container:hover {
+        cursor: pointer;
+        background-color: #6c757c; }
+      .igv-file-load-widget-container .igv-flw-input-container .igv-flw-input-row .igv-flw-drag-drop-target {
+        cursor: default;
+        margin-left: 8px;
+        width: 120px;
+        height: calc(36px - 8px);
+        line-height: calc(36px - 8px);
+        text-align: center;
+        border-color: #7F7F7F;
+        border-style: dashed;
+        border-width: thin;
+        border-radius: calc(2 * 2px); }
+      .igv-file-load-widget-container .igv-flw-input-container .igv-flw-input-row .igv-flw-local-file-name-container {
+        max-width: 400px;
+        height: 36px;
+        color: #373737;
+        line-height: 36px;
+        text-align: left;
+        font-weight: 400;
+        margin-left: 8px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis; }
+    .igv-file-load-widget-container .igv-flw-input-container .igv-flw-input-row-hover-state {
+      background-color: #efefef;
+      border-color: #7F7F7F; }
+  .igv-file-load-widget-container .igv-flw-error-message-container {
+    margin-top: 8px;
+    width: 95%;
+    height: 24px;
+    padding-left: 8px;
+    color: white;
+    font-size: 0.875rem;
+    background-color: rgba(59, 92, 127, 0.5);
+    display: flex;
+    flex-flow: row;
+    flex-wrap: nowrap;
+    justify-content: space-between;
+    align-items: center; }
+    .igv-file-load-widget-container .igv-flw-error-message-container div:first-child.igv-flw-error-message {
+      height: 24px;
+      width: 600px;
+      font-style: italic;
+      line-height: 24px;
+      text-align: left; }
+    .igv-file-load-widget-container .igv-flw-error-message-container div:last-child {
+      height: 24px;
+      width: 16px;
+      margin-right: 6px;
+      text-align: center;
+      line-height: 24px;
+      color: #373737; }
+    .igv-file-load-widget-container .igv-flw-error-message-container div:hover {
+      cursor: pointer; }
+  .igv-file-load-widget-container .igv-file-load-widget-ok-cancel {
+    width: 100%;
+    height: 28px;
+    margin-top: 32px;
+    color: white;
+    font-size: 0.875rem;
+    display: flex;
+    flex-flow: row;
+    flex-wrap: nowrap;
+    justify-content: flex-end;
+    align-items: center; }
+    .igv-file-load-widget-container .igv-file-load-widget-ok-cancel div {
+      width: 75px;
+      height: 28px;
+      line-height: 28px;
+      text-align: center;
+      border-color: transparent;
+      border-style: solid;
+      border-width: thin;
+      border-radius: 2px;
+      margin-right: 16px; }
+    .igv-file-load-widget-container .igv-file-load-widget-ok-cancel div:first-child {
+      margin-right: 22px;
+      background-color: #c4c4c4; }
+    .igv-file-load-widget-container .igv-file-load-widget-ok-cancel div:first-child:hover {
+      cursor: pointer;
+      background-color: #7f7f7f; }
+    .igv-file-load-widget-container .igv-file-load-widget-ok-cancel div:last-child {
+      background-color: #5ea4e0; }
+    .igv-file-load-widget-container .igv-file-load-widget-ok-cancel div:last-child:hover {
+      cursor: pointer;
+      background-color: #3b5c7f; }
+
+/*# sourceMappingURL=igv-widgets.css.map */

--- a/index.html
+++ b/index.html
@@ -12,11 +12,14 @@
     <!-- Font Awesome CSS-->
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css">
 
-    <!-- Bootstrap 4 CSS -->
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css">
+    <!-- Bootstrap 5 CSS -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css">
 
-    <!-- DataTables CSS -->
-    <link rel="stylesheet" href="https://cdn.datatables.net/v/dt/dt-1.10.20/sl-1.3.1/datatables.min.css"/>
+    <!-- infinite-table CSS -->
+    <link rel="stylesheet" href="node_modules/infinite-table/css/infinite-table.css">
+
+    <!-- Widget styles (extracted from igv-widgets v1.5.4) -->
+    <link rel="stylesheet" href="css/widgets.css">
 
     <!-- app CSS -->
     <link rel="stylesheet" href="css/app.css">
@@ -24,16 +27,11 @@
     <!-- Juicebox CSS-->
     <link rel="stylesheet" href="node_modules/juicebox.js/dist/css/juicebox.css"/>
 
-    <!-- Bootstrap 4 and Dependancies -->
-    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"></script>
+    <!-- Bootstrap 5 bundle (includes Popper, no jQuery) -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"></script>
 
     <!-- Dropbox Chooser API-->
     <script src="https://www.dropbox.com/static/api/2/dropins.js" id="dropboxjs" data-app-key="8glijwyao9fq8we"></script>
-
-    <!-- Datatables JS -->
-    <script src="https://cdn.datatables.net/v/dt/dt-1.10.20/sl-1.3.1/datatables.min.js"></script>
 
     <!-- Juicebox browser configuration -->
     <script src="./juiceboxConfig-private.js"></script>
@@ -46,7 +44,7 @@
 
 <nav class="navbar navbar-dark bg-dark fixed-top navbar-expand justify-content-between">
     <span class="navbar-brand">Juicebox Web App</span>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#hic-navbar-content">
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#hic-navbar-content">
         <span class="navbar-toggler-icon"></span>
     </button>
 
@@ -55,7 +53,7 @@
 
             <!-- App Clone -->
             <li class="nav-item">
-                <button id="juicebox-app-clone-button" type="button" class="btn btn-secondary btn-circle btn-sm ml-4 mt-2">
+                <button id="juicebox-app-clone-button" type="button" class="btn btn-secondary btn-circle btn-sm ms-4 mt-2">
                     <i class="fa fa-plus"></i>
                 </button>
             </li>
@@ -63,26 +61,26 @@
             <!-- Contact Map -->
             <li class="nav-item">
 
-                <div class="dropdown ml-2 mt-1">
+                <div class="dropdown ms-2 mt-1">
 
-                    <a id="hic-contact-map-dropdown" href="#" class="nav-link dropdown-toggle" data-toggle="dropdown">
+                    <a id="hic-contact-map-dropdown" href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown">
                         Load Map
                     </a>
 
                     <div id="hic-contact-map-dropdown-menu" class="dropdown-menu">
 
                         <!-- Select -->
-                        <a class="dropdown-item" href="#" data-toggle="modal" data-target="#hic-contact-map-modal">
+                        <a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#hic-contact-map-modal">
                             Juicebox Archive
                         </a>
 
                         <!-- ENCODE hosted maps -->
-                        <button id="hic-encode-hosted-contact-map-presentation-button" class="dropdown-item disabled" type="button" data-toggle="modal" data-target="#hic-encode-hosted-contact-map-modal">
+                        <button id="hic-encode-hosted-contact-map-presentation-button" class="dropdown-item disabled" type="button" data-bs-toggle="modal" data-bs-target="#hic-encode-hosted-contact-map-modal">
                             ENCODE
                         </button>
 
                         <!-- 4DN maps -->
-                        <button class="dropdown-item" type="button" data-toggle="modal" data-target="#hic-4dn-contact-map-modal">
+                        <button class="dropdown-item" type="button" data-bs-toggle="modal" data-bs-target="#hic-4dn-contact-map-modal">
                             4DN
                         </button>
 
@@ -114,7 +112,7 @@
                         </div>
 
                         <!-- URL -->
-                        <a class="dropdown-item" href="#" data-toggle="modal" data-target="#hic-load-url-modal">URL</a>
+                        <a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#hic-load-url-modal">URL</a>
                     </div>
 
 
@@ -125,26 +123,26 @@
             <!-- Control Map -->
             <li class="nav-item">
 
-                <div class="dropdown ml-2 mt-1">
+                <div class="dropdown ms-2 mt-1">
 
-                    <a id="hic-control-map-dropdown" href="#" class="nav-link dropdown-toggle disabled" data-toggle="dropdown">
+                    <a id="hic-control-map-dropdown" href="#" class="nav-link dropdown-toggle disabled" data-bs-toggle="dropdown">
                         Load "B" Map
                     </a>
 
                     <div id="hic-control-map-dropdown-menu" class="dropdown-menu">
 
                         <!-- Select -->
-                        <a class="dropdown-item" href="#" data-toggle="modal" data-target="#hic-contact-map-modal">
+                        <a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#hic-contact-map-modal">
                             Juicebox Archive
                         </a>
 
                         <!-- ENCODE hosted maps -->
-                        <button id="hic-encode-hosted-control-map-presentation-button" class="dropdown-item" type="button" data-toggle="modal" data-target="#hic-encode-hosted-contact-map-modal">
+                        <button id="hic-encode-hosted-control-map-presentation-button" class="dropdown-item" type="button" data-bs-toggle="modal" data-bs-target="#hic-encode-hosted-contact-map-modal">
                             ENCODE
                         </button>
 
                         <!-- 4DN maps -->
-                        <button class="dropdown-item" type="button" data-toggle="modal" data-target="#hic-4dn-contact-map-modal">
+                        <button class="dropdown-item" type="button" data-bs-toggle="modal" data-bs-target="#hic-4dn-contact-map-modal">
                             4DN
                         </button>
 
@@ -176,7 +174,7 @@
                         </div>
 
                         <!-- URL -->
-                        <a class="dropdown-item" href="#" data-toggle="modal" data-target="#hic-load-url-modal">URL</a>
+                        <a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#hic-load-url-modal">URL</a>
                     </div>
 
 
@@ -187,9 +185,9 @@
             <!-- Tracks -->
             <li class="nav-item">
 
-                <div class="dropdown ml-2 mt-1">
+                <div class="dropdown ms-2 mt-1">
 
-                    <a id="hic-track-dropdown-button" href="#" class="nav-link dropdown-toggle" data-toggle="dropdown">
+                    <a id="hic-track-dropdown-button" href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown">
                         Load Tracks
                     </a>
 
@@ -242,14 +240,14 @@
                         </div>
 
                         <!-- URL -->
-                        <a class="dropdown-item" href="#" data-toggle="modal" data-target="#track-load-url-modal">URL ...</a>
+                        <a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#track-load-url-modal">URL ...</a>
 
                         <!-- Genome Annotations (Frequently Used) -->
-                        <a class="dropdown-item" href="#" data-toggle="modal" data-target="#hic-annotation-datalist-modal">Frequently
+                        <a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#hic-annotation-datalist-modal">Frequently
                             Used</a>
 
                         <!-- 2D Annotations -->
-                        <a class="dropdown-item" href="#" data-toggle="modal" data-target="#hic-annotation-2D-datalist-modal">2D
+                        <a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#hic-annotation-2D-datalist-modal">2D
                             Annotations</a>
 
                         <div id="hic-annotations-section" class="dropdown-divider">
@@ -264,20 +262,20 @@
             <!-- Share -->
             <li class="nav-item">
 
-                <div class="dropdown ml-2 mt-1">
-                    <a id="hic-share-button" href="#" class="nav-link" data-toggle="modal" data-target="#hic-share-url-modal">
+                <div class="dropdown ms-2 mt-1">
+                    <a id="hic-share-button" href="#" class="nav-link" data-bs-toggle="modal" data-bs-target="#hic-share-url-modal">
                         Share
                     </a>
                 </div>
 
-<!--                <button id="hic-share-button" class="btn btn-outline-light btn-sm ml-2 mt-2" type="button" data-toggle="modal" data-target="#hic-share-url-modal">Share</button>-->
+<!--                <button id="hic-share-button" class="btn btn-outline-light btn-sm ms-2 mt-2" type="button" data-bs-toggle="modal" data-bs-target="#hic-share-url-modal">Share</button>-->
             </li>
 
             <!-- Session -->
             <li class="nav-item">
-                <div class="dropdown ml-2 mt-1">
+                <div class="dropdown ms-2 mt-1">
 
-                    <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown">
+                    <a href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown">
                         Session
                     </a>
 
@@ -300,14 +298,14 @@
                         <!-- Session Google Drive -->
 
                         <!-- Session URL -->
-                        <button class="dropdown-item" type="button" data-toggle="modal" data-target="#igv-app-session-url-modal">
+                        <button class="dropdown-item" type="button" data-bs-toggle="modal" data-bs-target="#igv-app-session-url-modal">
                             Load URL ...
                         </button>
 
                         <div class="dropdown-divider"></div>
 
                         <!-- Save Session Local file -->
-                        <button id="igv-app-save-session-button" class="dropdown-item" type="button" data-toggle="modal" data-target="#igv-app-session-save-modal">
+                        <button id="igv-app-save-session-button" class="dropdown-item" type="button" data-bs-toggle="modal" data-bs-target="#igv-app-session-save-modal">
                             Save ...
                         </button>
 
@@ -397,9 +395,7 @@
 
                 <div class="modal-header">
                     <div class="modal-title">Share</div>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
 
                 <div class="modal-body">
@@ -408,7 +404,7 @@
                         <!-- copy url -->
                         <div class="row">
                             <div class="col-md-9">
-                                <div class="form-group">
+                                <div class="mb-3">
                                     <input id="hic-share-url" type="text" class="form-control" placeholder="">
                                 </div>
                             </div>
@@ -446,7 +442,7 @@
 
                         <!-- embed widget -->
                         <div id="hic-embed-container" class="row">
-                            <div class="col-md-9 form-group">
+                            <div class="col-md-9 mb-3">
                             <textarea id="hic-embed" class="form-control" rows="4">
                             </textarea>
                             </div>

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     <script src="https://www.dropbox.com/static/api/2/dropins.js" id="dropboxjs" data-app-key="8glijwyao9fq8we"></script>
 
     <!-- Juicebox browser configuration -->
-    <script src="./juiceboxConfig-private.js"></script>
+    <script src="./juiceboxConfig.js"></script>
 
     <script type="module" src="js/app.js"></script>
 

--- a/js/alertSingleton.js
+++ b/js/alertSingleton.js
@@ -1,6 +1,5 @@
-// Inlined from igv-widgets/dist/igv-widgets.js. Styles are still provided by
-// igv-widgets' self-injected CSS (loaded as a side effect of the factory
-// imports in initializationHelper.js).
+// Inlined from igv-widgets/dist/igv-widgets.js. Styles are now provided by
+// css/widgets.css (extracted from igv-widgets v1.5.4 embedCSS.js).
 
 const httpMessages = {
     "401": "Access unauthorized",

--- a/js/contactMapLoad.js
+++ b/js/contactMapLoad.js
@@ -1,5 +1,4 @@
-import GenericDataSource from "../node_modules/data-modal/src/genericDataSource.js";
-import ModalTable from "../node_modules/data-modal/src/modalTable.js";
+import { GenericDataSource, createModalTable } from "../node_modules/infinite-table/src/index.js"
 
 import {aidenLabContactMapDatasourceConfigurator} from './aidenLabContactMapDatasourceConfig.js'
 import {encodeContactMapDatasourceConfiguration} from './encodeContactMapDatasourceConfig.js'
@@ -23,10 +22,8 @@ function configureContactMapLoaders({
                                         loadHandler
                                     }) {
 
-    // Bootstrap 4 dispatches `*.bs.*` events through jQuery only — native
-    // addEventListener will not catch them. Documented seam.
     dropdowns.forEach(dropdown => {
-        $(dropdown).on('show.bs.dropdown', function () {
+        dropdown.addEventListener('show.bs.dropdown', function () {
             // Contact or Control dropdown button
             const child = this.querySelector('.dropdown-toggle');
             const id = child.id;
@@ -75,18 +72,15 @@ function configureContactMapLoaders({
 
     if (mapMenu) {
 
-        const modalTableConfig =
-            {
-                id: dataModalId,
-                title: 'Contact Map',
-                selectionStyle: 'single',
-                pageLength: 10,
-                okHandler: async ([selection]) => {
-                    const {url, name} = selection
-                    await loadHandler(url, name, mapType)
-                }
+        contactMapModal = createModalTable({
+            id: dataModalId,
+            title: 'Contact Map',
+            selectionStyle: 'single',
+            okHandler: async ([selection]) => {
+                const {url, name} = selection
+                await loadHandler(url, name, mapType)
             }
-        contactMapModal = new ModalTable(modalTableConfig)
+        })
 
         const path =  mapMenu.items
         const config = aidenLabContactMapDatasourceConfigurator(path)
@@ -94,36 +88,28 @@ function configureContactMapLoaders({
         contactMapModal.setDatasource(datasource)
     }
 
-    const encodeModalTableConfig =
-        {
-            id: encodeHostedModalId,
-            title: 'ENCODE Hosted Contact Map',
-            selectionStyle: 'single',
-            pageLength: 10,
-            okHandler: async ([{ HREF, Description }]) => {
-                const urlPrefix = 'https://www.encodeproject.org'
-                const path = `${urlPrefix}${HREF}`
-                await loadHandler(path, Description, mapType)
-            }
+    encodeHostedContactMapModal = createModalTable({
+        id: encodeHostedModalId,
+        title: 'ENCODE Hosted Contact Map',
+        selectionStyle: 'single',
+        okHandler: async ([{ HREF, Description }]) => {
+            const urlPrefix = 'https://www.encodeproject.org'
+            const path = `${urlPrefix}${HREF}`
+            await loadHandler(path, Description, mapType)
         }
-
-    encodeHostedContactMapModal = new ModalTable(encodeModalTableConfig)
+    })
     encodeHostedContactMapModal.setDatasource( new GenericDataSource(encodeContactMapDatasourceConfiguration) )
 
 
-    const fourdnModalTableConfig =
-        {
-            id: fourdnModalId,
-            title: '4DN Hosted Contact Map',
-            selectionStyle: 'single',
-            pageLength: 10,
-            okHandler: async ([ item ]) => {
-                const { url, Dataset } = item
-                await loadHandler(url, Dataset, mapType)
-            }
+    fourdnContactMapModal = createModalTable({
+        id: fourdnModalId,
+        title: '4DN Hosted Contact Map',
+        selectionStyle: 'single',
+        okHandler: async ([ item ]) => {
+            const { url, Dataset } = item
+            await loadHandler(url, Dataset, mapType)
         }
-
-    fourdnContactMapModal = new ModalTable(fourdnModalTableConfig)
+    })
     fourdnContactMapModal.setDatasource( new GenericDataSource(fourdnContactMapDatasourceConfiguration) )
 
 }
@@ -132,25 +118,19 @@ function configureContactMapLoaders({
 function appendAndConfigureLoadURLModal(root, id, input_handler) {
 
     const html =
-        `<div id="${id}" class="modal fade">
-            <div class="modal-dialog  modal-lg">
+        `<div id="${id}" class="modal fade" tabindex="-1">
+            <div class="modal-dialog modal-lg">
                 <div class="modal-content">
 
                 <div class="modal-header">
                     <div class="modal-title">Load URL</div>
-
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
-
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
 
                 <div class="modal-body">
-
-                    <div class="form-group">
+                    <div class="mb-3">
                         <input type="text" class="form-control" placeholder="Enter URL">
                     </div>
-
                 </div>
 
                 </div>
@@ -166,8 +146,7 @@ function appendAndConfigureLoadURLModal(root, id, input_handler) {
         const path = target.value;
         target.value = "";
 
-        // BS4 modal control is jQuery-only — documented seam
-        $(`#${id}`).modal('hide');
+        bootstrap.Modal.getOrCreateInstance(modal).hide();
 
         input_handler(path);
     });

--- a/js/initializationHelper.js
+++ b/js/initializationHelper.js
@@ -1,11 +1,7 @@
 import {loadString} from "./stringLoader.js"
 
-
-import {
-    createSessionWidgets,
-    createTrackWidgetsWithTrackRegistry,
-    updateTrackMenus
-} from '../node_modules/igv-widgets/dist/igv-widgets.js'
+import {createSessionWidgets} from './widgets/sessionWidgets.js'
+import {createTrackWidgetsWithTrackRegistry, updateTrackMenus} from './widgets/trackWidgets.js'
 
 import {AlertSingleton} from './alertSingleton.js'
 
@@ -24,8 +20,7 @@ function initializationHelper(container, config) {
 
     configureSequenceAndRefSeqGeneTrackToggle()
 
-    // TODO(jquery-purge): jQuery wrapper retained for igv-widgets seam below
-    const $trackDropdownMenu = $('#hic-track-dropdown-menu')
+    const trackDropdownMenu = document.querySelector('#hic-track-dropdown-menu')
 
     createAppCloneButton(container)
 
@@ -38,17 +33,13 @@ function initializationHelper(container, config) {
 
     const initializeDropbox = async () => Promise.resolve(true)
 
-    // TODO(jquery-purge): igv-widgets factory requires jQuery objects as args
-    createTrackWidgetsWithTrackRegistry($(container),
-        $trackDropdownMenu,
-        $('#hic-local-track-file-input'),
+    createTrackWidgetsWithTrackRegistry(
+        container,
+        document.querySelector('#hic-local-track-file-input'),
         initializeDropbox,
-        $('#hic-track-dropdown-dropbox-button'),
-        undefined,
-        undefined,
+        document.querySelector('#hic-track-dropdown-dropbox-button'),
         ['hic-app-encode-signals-chip-modal', 'hic-app-encode-signals-other-modal', 'hic-app-encode-others-modal'],
         'track-load-url-modal',
-        undefined,
         undefined,
         config.trackRegistryFile,
         configurations => loadTracks(configurations))
@@ -77,21 +68,19 @@ function initializationHelper(container, config) {
 
     configureShareModal(container, config)
 
-    // BS4 `*.bs.*` events are jQuery-only — documented seam
-    $trackDropdownMenu.parent().on('shown.bs.dropdown', function () {
-        const browser = hic.getCurrentBrowser();
+    trackDropdownMenu.parentElement.addEventListener('shown.bs.dropdown', () => {
+        const browser = hic.getCurrentBrowser()
         if (undefined === browser || undefined === browser.dataset) {
-            AlertSingleton.present('Contact map must be loaded and selected before loading tracks');
+            AlertSingleton.present('Contact map must be loaded and selected before loading tracks')
         }
-    });
+    })
 
-    // BS4 event seam
-    $('#hic-control-map-dropdown-menu').parent().on('shown.bs.dropdown', function () {
-        const browser = hic.getCurrentBrowser();
+    document.querySelector('#hic-control-map-dropdown-menu').parentElement.addEventListener('shown.bs.dropdown', () => {
+        const browser = hic.getCurrentBrowser()
         if (undefined === browser || undefined === browser.dataset) {
-            AlertSingleton.present('Contact map must be loaded and selected before loading "B" map"');
+            AlertSingleton.present('Contact map must be loaded and selected before loading "B" map"')
         }
-    });
+    })
 
     const genomeChangeListener = async ({ data }) => {
 
@@ -118,11 +107,8 @@ function initializationHelper(container, config) {
             const response = await fetch(config.trackRegistryFile)
             const hash = await response.json()
 
-            // TODO(jquery-purge): igv-widgets `updateTrackMenus` requires jQuery object
-            const $dropdownMenu = $('#hic-track-dropdown-menu')
-
             if (hash[ data ]) {
-                updateTrackMenus(data, undefined, config.trackRegistryFile, $dropdownMenu)
+                updateTrackMenus(data, undefined, config.trackRegistryFile, document.querySelector('#hic-track-dropdown-menu'))
             }
 
 
@@ -276,8 +262,7 @@ function createAnnotationDatalistModals(root) {
             loadTracks([config]);
         }
 
-        // BS4 modal API seam
-        $('#hic-annotation-datalist-modal').modal('hide');
+        bootstrap.Modal.getInstance(document.querySelector('#hic-annotation-datalist-modal')).hide();
         annotation_input.value = '';
 
     });
@@ -301,8 +286,7 @@ function createAnnotationDatalistModals(root) {
             loadTracks([{url: path, name}]);
         }
 
-        // BS4 modal API seam
-        $('#hic-annotation-2D-datalist-modal').modal('hide');
+        bootstrap.Modal.getInstance(document.querySelector('#hic-annotation-2D-datalist-modal')).hide();
         annotation_2D_input.value = '';
     });
 
@@ -311,7 +295,7 @@ function createAnnotationDatalistModals(root) {
 function createGenericDataListModal(id, input_id, datalist_id, placeholder) {
 
     const generic_select_modal_string =
-        `<div id="${id}" class="modal">
+        `<div id="${id}" class="modal fade" tabindex="-1">
 
             <div class="modal-dialog modal-lg">
 
@@ -319,13 +303,11 @@ function createGenericDataListModal(id, input_id, datalist_id, placeholder) {
 
                     <div class="modal-header">
                         <div class="modal-title"></div>
-                        <button type="button" class="close" data-dismiss="modal">
-                            <span>&times;</span>
-                        </button>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
 
                     <div class="modal-body">
-                        <div class="form-group">
+                        <div class="mb-3">
                             <input type="text" id="${input_id}" list="${datalist_id}" placeholder="${placeholder}" class="form-control">
                             <datalist id="${datalist_id}"></datalist>
                         </div>
@@ -436,16 +418,14 @@ function configureSessionWidgets(container) {
     document.querySelector('div#igv-session-dropdown-menu > :nth-child(1)')
         .insertAdjacentHTML('afterend', dropboxDropdownItem('igv-app-dropdown-dropbox-session-file-button'))
 
-    // TODO(jquery-purge): igv-widgets factory requires jQuery container
-    createSessionWidgets($(container),
+    createSessionWidgets(
+        container,
         'juicebox-webapp',
         'igv-app-dropdown-local-session-file-input',
         () => Promise.resolve(true),
         'igv-app-dropdown-dropbox-session-file-button',
-        undefined,
         'igv-app-session-url-modal',
         'igv-app-session-save-modal',
-        undefined,
         async config => await hic.restoreSession(container, config),
         () => hic.toJSON()
     )
@@ -459,8 +439,7 @@ function configureShareModal(container, config) {
 
     const shareUrlModal = document.querySelector('#hic-share-url-modal');
 
-    // BS4 `*.bs.*` events are jQuery-only — documented seam
-    $(shareUrlModal).on('show.bs.modal', async function () {
+    shareUrlModal.addEventListener('show.bs.modal', async function () {
 
         let href = String(window.location.href);
 
@@ -502,8 +481,7 @@ function configureShareModal(container, config) {
 
     });
 
-    // BS4 event seam
-    $(shareUrlModal).on('hidden.bs.modal', function () {
+    shareUrlModal.addEventListener('hidden.bs.modal', function () {
         document.querySelector('#hic-embed-container').style.display = 'none';
         document.querySelector('#hic-qr-code-image').style.display = 'none';
     });
@@ -522,8 +500,7 @@ function configureShareModal(container, config) {
         document.querySelector('#hic-share-url').select();
         const success = document.execCommand('copy');
         if (success) {
-            // BS4 modal API seam
-            $('#hic-share-url-modal').modal('hide');
+            bootstrap.Modal.getInstance(shareUrlModal).hide();
         } else {
             alert("Copy not successful");
         }
@@ -533,8 +510,7 @@ function configureShareModal(container, config) {
         document.querySelector('#hic-embed').select();
         const success = document.execCommand('copy');
         if (success) {
-            // BS4 modal API seam
-            $('#hic-share-url-modal').modal('hide');
+            bootstrap.Modal.getInstance(shareUrlModal).hide();
         } else {
             alert("Copy not successful");
         }

--- a/js/widgets/dom-utils.js
+++ b/js/widgets/dom-utils.js
@@ -1,0 +1,33 @@
+function div(options) {
+    return create('div', options)
+}
+
+function create(tag, options) {
+    const elem = document.createElement(tag)
+    if (options) {
+        if (options.class) elem.classList.add(options.class)
+        if (options.id) elem.id = options.id
+        if (options.style) {
+            for (const key of Object.keys(options.style)) elem.style[key] = options.style[key]
+        }
+    }
+    return elem
+}
+
+function hide(elem) {
+    const cssStyle = getComputedStyle(elem)
+    if (cssStyle.display !== 'none') elem._initialDisplay = cssStyle.display
+    elem.style.display = 'none'
+}
+
+function show(elem, displayOverride) {
+    if (getComputedStyle(elem).display === 'none') {
+        elem.style.display = displayOverride || elem._initialDisplay || 'block'
+    }
+}
+
+function guid() {
+    return ('0000' + (Math.random() * Math.pow(36, 4) << 0).toString(36)).slice(-4)
+}
+
+export { create, div, hide, show, guid }

--- a/js/widgets/draggable.js
+++ b/js/widgets/draggable.js
@@ -1,0 +1,56 @@
+let dragData
+
+function makeDraggable(target, handle, constraint) {
+
+    handle.addEventListener('mousedown', dragStart.bind(target))
+
+    function dragStart(event) {
+
+        event.stopPropagation()
+        event.preventDefault()
+
+        const dragFunction = drag.bind(this)
+        const dragEndFunction = dragEnd.bind(this)
+        const computedStyle = getComputedStyle(this)
+
+        dragData = {
+            constraint,
+            dragFunction,
+            dragEndFunction,
+            screenX: event.screenX,
+            screenY: event.screenY,
+            top: parseInt(computedStyle.top.replace('px', '')),
+            left: parseInt(computedStyle.left.replace('px', ''))
+        }
+
+        document.addEventListener('mousemove', dragFunction)
+        document.addEventListener('mouseup', dragEndFunction)
+        document.addEventListener('mouseleave', dragEndFunction)
+        document.addEventListener('mouseexit', dragEndFunction)
+    }
+}
+
+function drag(event) {
+    if (!dragData) return
+    event.stopPropagation()
+    event.preventDefault()
+    const dx = event.screenX - dragData.screenX
+    const dy = event.screenY - dragData.screenY
+    const left = dragData.left + dx
+    const top = dragData.constraint ? Math.max(dragData.constraint.minY, dragData.top + dy) : dragData.top + dy
+    this.style.left = `${left}px`
+    this.style.top = `${top}px`
+}
+
+function dragEnd(event) {
+    if (!dragData) return
+    event.stopPropagation()
+    event.preventDefault()
+    document.removeEventListener('mousemove', dragData.dragFunction)
+    document.removeEventListener('mouseup', dragData.dragEndFunction)
+    document.removeEventListener('mouseleave', dragData.dragEndFunction)
+    document.removeEventListener('mouseexit', dragData.dragEndFunction)
+    dragData = undefined
+}
+
+export default makeDraggable

--- a/js/widgets/encodeTrackDatasourceConfigurator.js
+++ b/js/widgets/encodeTrackDatasourceConfigurator.js
@@ -1,0 +1,102 @@
+/**
+ * Factory function to create a configuration object for the EncodeTrackDatasource given a genomicId and type.
+ * Verbatim port from igv-widgets v1.5.4.
+ */
+function encodeTrackDatasourceConfigurator(genomeId, type) {
+
+    const root = 'https://s3.amazonaws.com/igv.org.app/encode/'
+    let url
+
+    switch (type) {
+        case 'signals-chip':
+            url = `${root}${canonicalId(genomeId)}.signals.chip.txt`
+            break
+        case 'signals-other':
+            url = `${root}${canonicalId(genomeId)}.signals.other.txt`
+            break
+        case 'other':
+            url = `${root}${canonicalId(genomeId)}.other.txt`
+            break
+    }
+
+    return {
+        isJSON: false,
+        url,
+        sort: encodeSort,
+        columns: [
+            'Biosample',
+            'AssayType',
+            'Target',
+            'BioRep',
+            'TechRep',
+            'OutputType',
+            'Format',
+            'Lab',
+            'Accession',
+            'Experiment'
+        ],
+        columnDefs: {
+            AssayType: { title: 'Assay Type' },
+            OutputType: { title: 'Output Type' },
+            BioRep: { title: 'Bio Rep' },
+            TechRep: { title: 'Tech Rep' }
+        },
+        rowHandler: row => {
+            const name = constructName(row)
+            const url = `https://www.encodeproject.org${row['HREF']}`
+            const color = colorForTarget(row['Target'])
+            return { name, url, color }
+        }
+    }
+}
+
+function supportsGenome(genomeId) {
+    const knownGenomes = new Set(['ce10', 'ce11', 'dm3', 'dm6', 'GRCh38', 'hg19', 'mm9', 'mm10'])
+    return knownGenomes.has(canonicalId(genomeId))
+}
+
+function canonicalId(genomeId) {
+    switch (genomeId) {
+        case 'hg38':     return 'GRCh38'
+        case 'CRCh37':   return 'hg19'
+        case 'GRCm38':   return 'mm10'
+        case 'NCBI37':   return 'mm9'
+        case 'WBcel235': return 'ce11'
+        case 'WS220':    return 'ce10'
+        default:         return genomeId
+    }
+}
+
+function constructName(record) {
+    let name = record['Biosample'] || ''
+    if (record['Target']) name += ' ' + record['Target']
+    if (record['AssayType'].toLowerCase() !== 'chip-seq') name += ' ' + record['AssayType']
+    return name
+}
+
+function encodeSort(a, b) {
+    const aa1 = a['Assay Type'], aa2 = b['Assay Type']
+    const cc1 = a['Biosample'],  cc2 = b['Biosample']
+    const tt1 = a['Target'],     tt2 = b['Target']
+
+    if (aa1 === aa2) {
+        if (cc1 === cc2) {
+            if (tt1 === tt2) return 0
+            return tt1 < tt2 ? -1 : 1
+        }
+        return cc1 < cc2 ? -1 : 1
+    }
+    return aa1 < aa2 ? -1 : 1
+}
+
+function colorForTarget(target) {
+    const t = target.toLowerCase()
+    if (t.startsWith('h3k4'))  return 'rgb(0,150,0)'
+    if (t.startsWith('h3k27')) return 'rgb(200,0,0)'
+    if (t.startsWith('h3k36')) return 'rgb(0,0,150)'
+    if (t.startsWith('h3k9'))  return 'rgb(100,0,0)'
+    if (t === 'ctcf')          return 'black'
+    return undefined
+}
+
+export { encodeTrackDatasourceConfigurator, supportsGenome }

--- a/js/widgets/fileLoad.js
+++ b/js/widgets/fileLoad.js
@@ -1,0 +1,57 @@
+import { AlertSingleton } from '../alertSingleton.js'
+
+/**
+ * Base class for handling local file input and Dropbox button click. Google Drive paths
+ * are intentionally omitted — juicebox-web does not enable Google integration.
+ */
+class FileLoad {
+
+    constructor({ localFileInput, initializeDropbox, dropboxButton }) {
+
+        localFileInput.addEventListener('change', async () => {
+            if (FileLoad.isValidLocalFileInput(localFileInput)) {
+                try {
+                    await this.loadPaths(Array.from(localFileInput.files))
+                } catch (e) {
+                    console.error(e)
+                    AlertSingleton.present(e)
+                }
+                localFileInput.value = ''
+            }
+        })
+
+        if (dropboxButton) {
+            dropboxButton.addEventListener('click', async () => {
+                const result = await initializeDropbox()
+                if (true !== result) {
+                    AlertSingleton.present('Cannot connect to Dropbox')
+                    return
+                }
+                Dropbox.choose({
+                    success: async dbFiles => {
+                        try {
+                            await this.loadPaths(dbFiles.map(f => f.link))
+                        } catch (e) {
+                            console.error(e)
+                            AlertSingleton.present(e)
+                        }
+                    },
+                    cancel: () => {},
+                    linkType: 'preview',
+                    multiselect: true,
+                    folderselect: false
+                })
+            })
+        }
+    }
+
+    async loadPaths(paths) {
+        // override in subclass
+    }
+
+    static isValidLocalFileInput(input) {
+        return input.files && input.files.length > 0
+    }
+}
+
+export default FileLoad

--- a/js/widgets/fileLoadManager.js
+++ b/js/widgets/fileLoadManager.js
@@ -1,0 +1,28 @@
+import { FileUtils } from '../../node_modules/igv-utils/src/index.js'
+
+class FileLoadManager {
+
+    constructor() {
+        this.dictionary = {}
+    }
+
+    inputHandler(path, isIndexFile) {
+        this.ingestPath(path, isIndexFile)
+    }
+
+    ingestPath(path, isIndexFile) {
+        const key = isIndexFile ? 'index' : 'data'
+        this.dictionary[key] = path.trim()
+    }
+
+    indexName() { return itemName(this.dictionary.index) }
+    dataName()  { return itemName(this.dictionary.data)  }
+
+    reset() { this.dictionary = {} }
+}
+
+function itemName(item) {
+    return FileUtils.isFilePath(item) ? item.name : item
+}
+
+export default FileLoadManager

--- a/js/widgets/fileLoadWidget.js
+++ b/js/widgets/fileLoadWidget.js
@@ -1,0 +1,143 @@
+import * as DOMUtils from './dom-utils.js'
+import * as UIUtils from './ui-utils.js'
+
+class FileLoadWidget {
+
+    constructor({ widgetParent, dataTitle, indexTitle, mode, fileLoadManager, dataOnly, doURL }) {
+
+        dataTitle = dataTitle || 'Data'
+        indexTitle = indexTitle || 'Index'
+        dataOnly = dataOnly || false
+        doURL = doURL || false
+
+        this.fileLoadManager = fileLoadManager
+
+        this.container = DOMUtils.div({ class: 'igv-file-load-widget-container' })
+        widgetParent.appendChild(this.container)
+
+        const config = 'localFile' === mode
+            ? { parent: this.container, doURL: false, dataTitle: dataTitle + ' file', indexTitle: indexTitle + ' file', dataOnly }
+            : { parent: this.container, doURL: true,  dataTitle: dataTitle + ' URL',  indexTitle: indexTitle + ' URL',  dataOnly }
+
+        this.createInputContainer(config)
+
+        this.error_message = DOMUtils.div({ class: 'igv-flw-error-message-container' })
+        this.container.appendChild(this.error_message)
+        this.error_message.appendChild(DOMUtils.div({ class: 'igv-flw-error-message' }))
+
+        UIUtils.attachDialogCloseHandlerWithParent(this.error_message, () => this.dismissErrorMessage())
+
+        this.dismissErrorMessage()
+    }
+
+    retrievePaths() {
+
+        this.fileLoadManager.ingestPath(this.inputData.value, false)
+        if (this.inputIndex) this.fileLoadManager.ingestPath(this.inputIndex.value, true)
+
+        const paths = []
+        if (this.fileLoadManager.dictionary) {
+            if (this.fileLoadManager.dictionary.data)  paths.push(this.fileLoadManager.dictionary.data)
+            if (this.fileLoadManager.dictionary.index) paths.push(this.fileLoadManager.dictionary.index)
+        }
+
+        // clear input elements
+        this.container.querySelectorAll('.igv-flw-input-row').forEach(row => {
+            const input = row.querySelector('input')
+            if (input) input.value = ''
+        })
+
+        return paths
+    }
+
+    presentErrorMessage(message) {
+        this.error_message.querySelector('.igv-flw-error-message').textContent = message
+        DOMUtils.show(this.error_message)
+    }
+
+    dismissErrorMessage() {
+        DOMUtils.hide(this.error_message)
+        this.error_message.querySelector('.igv-flw-error-message').textContent = ''
+    }
+
+    present() { DOMUtils.show(this.container) }
+
+    dismiss() {
+        this.dismissErrorMessage()
+        this.container.querySelectorAll('.igv-flw-input-row').forEach(row => {
+            const input = row.querySelector('input')
+            if (input) input.value = ''
+        })
+        this.fileLoadManager.reset()
+    }
+
+    createInputContainer({ parent, doURL, dataTitle, indexTitle, dataOnly }) {
+
+        const container = DOMUtils.div({ class: 'igv-flw-input-container' })
+        parent.appendChild(container)
+
+        const dataRow = DOMUtils.div({ class: 'igv-flw-input-row' })
+        container.appendChild(dataRow)
+
+        let label = DOMUtils.div({ class: 'igv-flw-input-label' })
+        dataRow.appendChild(label)
+        label.textContent = dataTitle
+
+        if (doURL) this.createURLContainer(dataRow, 'igv-flw-data-url', false)
+        else       this.createLocalFileContainer(dataRow, 'igv-flw-local-data-file', false)
+
+        if (dataOnly) return
+
+        const indexRow = DOMUtils.div({ class: 'igv-flw-input-row' })
+        container.appendChild(indexRow)
+
+        label = DOMUtils.div({ class: 'igv-flw-input-label' })
+        indexRow.appendChild(label)
+        label.textContent = indexTitle
+
+        if (doURL) this.createURLContainer(indexRow, 'igv-flw-index-url', true)
+        else       this.createLocalFileContainer(indexRow, 'igv-flw-local-index-file', true)
+    }
+
+    createURLContainer(parent, id, isIndexFile) {
+        const input = DOMUtils.create('input')
+        input.setAttribute('type', 'text')
+        parent.appendChild(input)
+        if (isIndexFile) this.inputIndex = input
+        else             this.inputData = input
+    }
+
+    createLocalFileContainer(parent, id, isIndexFile) {
+
+        const file_chooser = DOMUtils.div({ class: 'igv-flw-file-chooser-container' })
+        parent.appendChild(file_chooser)
+
+        const str = `${id}${DOMUtils.guid()}`
+
+        const label = DOMUtils.create('label')
+        label.setAttribute('for', str)
+        file_chooser.appendChild(label)
+        label.textContent = 'Choose file'
+
+        const input = DOMUtils.create('input', { class: 'igv-flw-file-chooser-input' })
+        input.setAttribute('id', str)
+        input.setAttribute('name', str)
+        input.setAttribute('type', 'file')
+        file_chooser.appendChild(input)
+
+        const file_name = DOMUtils.div({ class: 'igv-flw-local-file-name-container' })
+        parent.appendChild(file_name)
+        DOMUtils.hide(file_name)
+
+        input.addEventListener('change', e => {
+            this.dismissErrorMessage()
+            const file = e.target.files[0]
+            this.fileLoadManager.inputHandler(file, isIndexFile)
+            file_name.textContent = file.name
+            file_name.setAttribute('title', file.name)
+            DOMUtils.show(file_name)
+        })
+    }
+}
+
+export default FileLoadWidget

--- a/js/widgets/genericSelectModal.js
+++ b/js/widgets/genericSelectModal.js
@@ -1,0 +1,33 @@
+function createGenericSelectModal(id, select_id) {
+
+    return `<div id="${id}" class="modal fade" tabindex="-1">
+
+        <div class="modal-dialog modal-lg">
+
+            <div class="modal-content">
+
+                <div class="modal-header">
+                    <div class="modal-title"></div>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <select id="${select_id}" class="form-control" multiple></select>
+                    </div>
+                    <div id="igv-widgets-generic-select-modal-footnotes"></div>
+                </div>
+
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-sm btn-secondary" data-bs-dismiss="modal">OK</button>
+                </div>
+
+            </div>
+
+        </div>
+
+    </div>`
+}
+
+export { createGenericSelectModal }

--- a/js/widgets/icons.js
+++ b/js/widgets/icons.js
@@ -1,0 +1,17 @@
+const icons = {
+    'times': [384, 512, 'M323.1 441l53.9-53.9c9.4-9.4 9.4-24.5 0-33.9L279.8 256l97.2-97.2c9.4-9.4 9.4-24.5 0-33.9L323.1 71c-9.4-9.4-24.5-9.4-33.9 0L192 168.2 94.8 71c-9.4-9.4-24.5-9.4-33.9 0L7 124.9c-9.4 9.4-9.4 24.5 0 33.9l97.2 97.2L7 353.2c-9.4 9.4-9.4 24.5 0 33.9L60.9 441c9.4 9.4 24.5 9.4 33.9 0l97.2-97.2 97.2 97.2c9.3 9.3 24.5 9.3 33.9 0z']
+}
+
+function createIcon(name, color) {
+    color = color || 'currentColor'
+    const icon = icons[name]
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    svg.setAttributeNS(null, 'viewBox', `0 0 ${icon[0]} ${icon[1]}`)
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+    path.setAttributeNS(null, 'fill', color)
+    path.setAttributeNS(null, 'd', icon[2])
+    svg.appendChild(path)
+    return svg
+}
+
+export { createIcon }

--- a/js/widgets/multipleTrackFileLoad.js
+++ b/js/widgets/multipleTrackFileLoad.js
@@ -1,0 +1,103 @@
+import { AlertSingleton } from '../alertSingleton.js'
+import { FileUtils, URIUtils } from '../../node_modules/igv-utils/src/index.js'
+
+/**
+ * Track-loading equivalent of FileLoad, but with multi-file selection and
+ * data-file/index-file pairing. Google Drive paths intentionally omitted.
+ */
+class MultipleTrackFileLoad {
+
+    constructor({ localFileInput, initializeDropbox, dropboxButton, fileLoadHandler, multipleFileSelection }) {
+
+        this.fileLoadHandler = fileLoadHandler
+
+        localFileInput.addEventListener('change', async () => {
+            if (MultipleTrackFileLoad.isValidLocalFileInput(localFileInput)) {
+                const paths = Array.from(localFileInput.files)
+                localFileInput.value = ''
+                await this.loadPaths(paths)
+            }
+        })
+
+        if (dropboxButton) {
+            dropboxButton.addEventListener('click', async () => {
+                const result = await initializeDropbox()
+                if (true !== result) {
+                    AlertSingleton.present('Cannot connect to Dropbox')
+                    return
+                }
+                Dropbox.choose({
+                    success: dbFiles => this.loadPaths(dbFiles.map(({ link }) => link)),
+                    cancel: () => {},
+                    linkType: 'preview',
+                    multiselect: multipleFileSelection,
+                    folderselect: false
+                })
+            })
+        }
+    }
+
+    async loadPaths(paths) {
+        await ingestPaths({ paths, fileLoadHandler: this.fileLoadHandler })
+    }
+
+    static isValidLocalFileInput(input) {
+        return input.files && input.files.length > 0
+    }
+
+    static getFilename(path) {
+        if (path instanceof File) return path.name
+        return URIUtils.parseUri(path).file
+    }
+}
+
+async function ingestPaths({ paths, fileLoadHandler }) {
+
+    try {
+        const indexLUT = new Map()
+        const dataPaths = []
+
+        for (const path of paths) {
+            const name = MultipleTrackFileLoad.getFilename(path)
+            const extension = FileUtils.getExtension(name)
+
+            if (indexExtensions.has(extension)) {
+                indexLUT.set(createIndexLUTKey(name, extension), { indexURL: path })
+            } else {
+                dataPaths.push(path)
+            }
+        }
+
+        const configurations = []
+        for (const dataPath of dataPaths) {
+            const filename = MultipleTrackFileLoad.getFilename(dataPath)
+
+            if (indexLUT.has(filename)) {
+                const { indexURL } = indexLUT.get(filename)
+                configurations.push({ url: dataPath, filename, indexURL, name: filename, _derivedName: true })
+            } else if (requireIndex.has(FileUtils.getExtension(filename))) {
+                throw new Error(`Unable to load track file ${filename} - you must select both ${filename} and its corresponding index file`)
+            } else {
+                configurations.push({ url: dataPath, filename, name: filename, _derivedName: true })
+            }
+        }
+
+        if (configurations.length > 0) fileLoadHandler(configurations)
+
+    } catch (e) {
+        console.error(e)
+        AlertSingleton.present(e.message)
+    }
+}
+
+const indexExtensions = new Set(['bai', 'csi', 'tbi', 'idx', 'crai', 'fai'])
+const requireIndex   = new Set(['bam', 'cram', 'fa', 'fasta'])
+
+function createIndexLUTKey(name, extension) {
+    const key = name.substring(0, name.length - (extension.length + 1))
+    if ('bai'  === extension && !key.endsWith('bam'))  return `${key}.bam`
+    if ('crai' === extension && !key.endsWith('cram')) return `${key}.cram`
+    return key
+}
+
+export default MultipleTrackFileLoad

--- a/js/widgets/sessionFileLoad.js
+++ b/js/widgets/sessionFileLoad.js
@@ -1,0 +1,29 @@
+import { FileUtils, igvxhr } from '../../node_modules/igv-utils/src/index.js'
+import FileLoad from './fileLoad.js'
+
+class SessionFileLoad extends FileLoad {
+
+    constructor({ localFileInput, initializeDropbox, dropboxButton, loadHandler }) {
+        super({ localFileInput, initializeDropbox, dropboxButton })
+        this.loadHandler = loadHandler
+    }
+
+    async loadPaths(paths) {
+
+        const path = paths[0]
+
+        if ('json' === FileUtils.getExtension(path)) {
+            const json = await igvxhr.loadJson(path)
+            this.loadHandler(json)
+        } else if ('xml' === FileUtils.getExtension(path)) {
+            const key = FileUtils.isFilePath(path) ? 'file' : 'url'
+            const o = {}
+            o[key] = path
+            this.loadHandler(o)
+        } else {
+            throw new Error('Session file did not load - invalid format')
+        }
+    }
+}
+
+export default SessionFileLoad

--- a/js/widgets/sessionWidgets.js
+++ b/js/widgets/sessionWidgets.js
@@ -1,0 +1,119 @@
+import { FileUtils } from '../../node_modules/igv-utils/src/index.js'
+import FileLoadManager from './fileLoadManager.js'
+import FileLoadWidget from './fileLoadWidget.js'
+import SessionFileLoad from './sessionFileLoad.js'
+import { createURLModal } from './urlModal.js'
+import { configureModal } from './utils.js'
+
+/**
+ * Vanilla-JS / Bootstrap-5 port of igv-widgets v1.5.4 createSessionWidgets.
+ * Public API takes plain DOM elements / IDs (no jQuery objects).
+ */
+function createSessionWidgets(rootContainer,
+                              prefix,
+                              localFileInputId,
+                              initializeDropbox,
+                              dropboxButtonId,
+                              urlModalId,
+                              sessionSaveModalId,
+                              loadHandler,
+                              JSONProvider) {
+
+    const urlModalElement = createURLModal(urlModalId, 'Session URL')
+    rootContainer.appendChild(urlModalElement)
+
+    const fileLoadWidget = new FileLoadWidget({
+        widgetParent: urlModalElement.querySelector('.modal-body'),
+        dataTitle: 'Session',
+        indexTitle: undefined,
+        mode: 'url',
+        fileLoadManager: new FileLoadManager(),
+        dataOnly: true,
+        doURL: undefined
+    })
+
+    const sessionFileLoad = new SessionFileLoad({
+        localFileInput: document.querySelector(`#${localFileInputId}`),
+        initializeDropbox,
+        dropboxButton: dropboxButtonId ? document.querySelector(`#${dropboxButtonId}`) : undefined,
+        loadHandler
+    })
+
+    configureModal(fileLoadWidget, urlModalElement, async fileLoadWidget => {
+        await sessionFileLoad.loadPaths(fileLoadWidget.retrievePaths())
+        return true
+    })
+
+    configureSaveSessionModal(rootContainer, prefix, JSONProvider, sessionSaveModalId)
+}
+
+function configureSaveSessionModal(rootContainer, prefix, JSONProvider, sessionSaveModalId) {
+
+    const html = `<div id="${sessionSaveModalId}" class="modal fade igv-app-file-save-modal" tabindex="-1">
+
+        <div class="modal-dialog modal-lg">
+
+            <div class="modal-content">
+
+                <div class="modal-header">
+                    <div class="modal-title">
+                        <div>Save Session File</div>
+                    </div>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+
+                <div class="modal-body">
+                    <input class="form-control" type="text" placeholder="igv-app-session.json">
+                    <div>Enter session filename with .json suffix</div>
+                </div>
+
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-sm btn-secondary">OK</button>
+                </div>
+
+            </div>
+
+        </div>
+
+    </div>`
+
+    const modalElement = document.createRange().createContextualFragment(html).firstChild
+    rootContainer.appendChild(modalElement)
+
+    const modal = bootstrap.Modal.getOrCreateInstance(modalElement)
+    const input = modalElement.querySelector('input')
+
+    const okHandler = () => {
+        const extensions = new Set(['json', 'xml'])
+        let filename = input.value
+
+        if (undefined === filename || '' === filename) {
+            filename = input.getAttribute('placeholder')
+        } else if (false === extensions.has(FileUtils.getExtension(filename))) {
+            filename = filename + '.json'
+        }
+
+        const json = JSONProvider()
+        if (json) {
+            const jsonString = JSON.stringify(json, null, '\t')
+            const data = URL.createObjectURL(new Blob([jsonString], { type: 'application/octet-stream' }))
+            FileUtils.download(filename, data)
+        }
+
+        modal.hide()
+    }
+
+    const okButton = modalElement.querySelector('.modal-footer button:nth-child(2)')
+    okButton.addEventListener('click', okHandler)
+
+    modalElement.addEventListener('show.bs.modal', () => {
+        input.value = `${prefix}-session.json`
+    })
+
+    input.addEventListener('keyup', e => {
+        if ('Enter' === e.key) okHandler()
+    })
+}
+
+export { createSessionWidgets }

--- a/js/widgets/trackURLModal.js
+++ b/js/widgets/trackURLModal.js
@@ -1,0 +1,31 @@
+function createTrackURLModal(id) {
+
+    const html = `<div id="${id}" class="modal fade" tabindex="-1">
+
+        <div class="modal-dialog modal-lg">
+
+            <div class="modal-content">
+
+                <div class="modal-header">
+                    <div class="modal-title">Track URL</div>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+
+                <div class="modal-body">
+                </div>
+
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-sm btn-secondary" data-bs-dismiss="modal">OK</button>
+                </div>
+
+            </div>
+
+        </div>
+
+    </div>`
+
+    return document.createRange().createContextualFragment(html).firstChild
+}
+
+export { createTrackURLModal }

--- a/js/widgets/trackWidgets.js
+++ b/js/widgets/trackWidgets.js
@@ -1,0 +1,243 @@
+import { GenericDataSource, createModalTable } from '../../node_modules/infinite-table/src/index.js'
+import { encodeTrackDatasourceConfigurator, supportsGenome } from './encodeTrackDatasourceConfigurator.js'
+import { AlertSingleton } from '../alertSingleton.js'
+import { createGenericSelectModal } from './genericSelectModal.js'
+import { createTrackURLModal } from './trackURLModal.js'
+import FileLoadManager from './fileLoadManager.js'
+import FileLoadWidget from './fileLoadWidget.js'
+import MultipleTrackFileLoad from './multipleTrackFileLoad.js'
+import { configureModal } from './utils.js'
+
+let encodeModalTables = []
+let customModalTable
+let genericSelectModalElement = undefined
+
+/**
+ * Vanilla-JS / Bootstrap-5 / infinite-table port of igv-widgets v1.5.4
+ * createTrackWidgetsWithTrackRegistry + updateTrackMenus. Public API takes
+ * plain DOM elements / IDs (no jQuery objects).
+ */
+function createTrackWidgetsWithTrackRegistry(igvMain,
+                                             localFileInput,
+                                             initializeDropbox,
+                                             dropboxButton,
+                                             encodeTrackModalIds,
+                                             urlModalId,
+                                             selectModalIdOrUndefined,
+                                             trackRegistryFile,
+                                             trackLoadHandler) {
+
+    const urlModalElement = createTrackURLModal(urlModalId)
+    igvMain.appendChild(urlModalElement)
+
+    const fileLoadWidget = new FileLoadWidget({
+        widgetParent: urlModalElement.querySelector('.modal-body'),
+        dataTitle: 'Track',
+        indexTitle: 'Index',
+        mode: 'url',
+        fileLoadManager: new FileLoadManager(),
+        dataOnly: false,
+        doURL: true
+    })
+
+    configureModal(fileLoadWidget, urlModalElement, async fileLoadWidget => {
+        await multipleTrackFileLoad.loadPaths(fileLoadWidget.retrievePaths())
+        return true
+    })
+
+    const multipleTrackFileLoad = new MultipleTrackFileLoad({
+        localFileInput,
+        initializeDropbox,
+        dropboxButton,
+        fileLoadHandler: trackLoadHandler,
+        multipleFileSelection: true
+    })
+
+    for (const modalID of encodeTrackModalIds) {
+        encodeModalTables.push(createModalTable({
+            id: modalID,
+            title: 'ENCODE',
+            selectionStyle: 'multi',
+            okHandler: trackLoadHandler
+        }))
+    }
+
+    customModalTable = createModalTable({
+        id: 'igv-custom-modal',
+        title: 'UNTITLED',
+        selectionStyle: 'multi',
+        okHandler: trackLoadHandler
+    })
+
+    if (selectModalIdOrUndefined) {
+        const selectModalHTML = createGenericSelectModal(selectModalIdOrUndefined, `${selectModalIdOrUndefined}-select`)
+        const fragment = document.createRange().createContextualFragment(selectModalHTML)
+        genericSelectModalElement = fragment.firstChild
+        igvMain.appendChild(genericSelectModalElement)
+
+        const select = genericSelectModalElement.querySelector('select')
+        const okButton = genericSelectModalElement.querySelector('.modal-footer button:nth-child(2)')
+
+        const okHandler = () => {
+            const configurations = []
+            const selectedOptions = select.querySelectorAll('option:checked')
+            for (const option of selectedOptions) {
+                if (option._track) configurations.push(option._track)
+                option.removeAttribute('selected')
+            }
+            if (configurations.length > 0) trackLoadHandler(configurations)
+            bootstrap.Modal.getInstance(genericSelectModalElement).hide()
+        }
+
+        okButton.addEventListener('click', okHandler)
+
+        genericSelectModalElement.addEventListener('keypress', event => {
+            if ('Enter' === event.key) okHandler()
+        })
+    }
+}
+
+async function updateTrackMenus(genomeID, GtexUtilsOrUndefined, trackRegistryFile, dropdownMenu) {
+
+    const id_prefix = 'genome_specific_'
+
+    const divider = dropdownMenu.querySelector('.dropdown-divider')
+
+    // Remove previously inserted genome-specific items
+    dropdownMenu.querySelectorAll(`[id^=${id_prefix}]`).forEach(el => el.remove())
+
+    const paths = await getPathsWithTrackRegistryFile(genomeID, trackRegistryFile)
+    if (undefined === paths) {
+        console.warn(`There are no tracks in the track registry for genome ${genomeID}`)
+        return
+    }
+
+    let responses = []
+    try {
+        responses = await Promise.all(paths.map(path => fetch(path)))
+    } catch (e) {
+        AlertSingleton.present(e.message)
+    }
+
+    let jsons = []
+    try {
+        jsons = await Promise.all(responses.map(r => r.json()))
+    } catch (e) {
+        AlertSingleton.present(e.message)
+    }
+
+    const buttonConfigurations = []
+
+    for (const json of jsons) {
+        if (true === supportsGenome(genomeID) && 'ENCODE' === json.type) {
+            encodeModalTables[0].setDatasource(new GenericDataSource(encodeTrackDatasourceConfigurator(genomeID, 'signals-chip')))
+            encodeModalTables[1].setDatasource(new GenericDataSource(encodeTrackDatasourceConfigurator(genomeID, 'signals-other')))
+            encodeModalTables[2].setDatasource(new GenericDataSource(encodeTrackDatasourceConfigurator(genomeID, 'other')))
+        } else if (GtexUtilsOrUndefined && 'GTEX' === json.type) {
+            let info
+            try {
+                info = await GtexUtilsOrUndefined.getTissueInfo(json.datasetId)
+            } catch (e) {
+                AlertSingleton.present(e.message)
+            }
+            if (info) {
+                json.tracks = info.tissueInfo.map(tissue => GtexUtilsOrUndefined.trackConfiguration(tissue))
+            }
+        }
+        buttonConfigurations.push(json)
+    }
+
+    for (const buttonConfiguration of buttonConfigurations.reverse()) {
+
+        if (buttonConfiguration.type && 'custom-data-modal' === buttonConfiguration.type) {
+
+            if (buttonConfiguration.description) customModalTable.setDescription(buttonConfiguration.description)
+
+            createDropdownButton(divider, buttonConfiguration.label, id_prefix)
+                .addEventListener('click', () => {
+                    customModalTable.setDatasource(new GenericDataSource(buttonConfiguration))
+                    customModalTable.setTitle(buttonConfiguration.label)
+                    customModalTable.modal.show()
+                })
+
+        } else if (buttonConfiguration.type && 'ENCODE' === buttonConfiguration.type) {
+
+            if (true === supportsGenome(genomeID)) {
+
+                if (buttonConfiguration.description) {
+                    encodeModalTables[0].setDescription(buttonConfiguration.description)
+                    encodeModalTables[1].setDescription(buttonConfiguration.description)
+                    encodeModalTables[2].setDescription(buttonConfiguration.description)
+                }
+
+                createDropdownButton(divider, 'ENCODE Other', id_prefix)
+                    .addEventListener('click', () => encodeModalTables[2].modal.show())
+
+                createDropdownButton(divider, 'ENCODE Signals - Other', id_prefix)
+                    .addEventListener('click', () => encodeModalTables[1].modal.show())
+
+                createDropdownButton(divider, 'ENCODE Signals - ChIP', id_prefix)
+                    .addEventListener('click', () => encodeModalTables[0].modal.show())
+            }
+
+        } else if (genericSelectModalElement) {
+
+            createDropdownButton(divider, buttonConfiguration.label, id_prefix)
+                .addEventListener('click', () => {
+                    configureSelectModal(genericSelectModalElement, buttonConfiguration)
+                    bootstrap.Modal.getOrCreateInstance(genericSelectModalElement).show()
+                })
+        }
+    }
+}
+
+function createDropdownButton(divider, buttonText, id_prefix) {
+    const button = document.createElement('button')
+    button.className = 'dropdown-item'
+    button.type = 'button'
+    button.textContent = `${buttonText} ...`
+    button.id = `${id_prefix}${buttonText.toLowerCase().split(' ').join('_')}`
+    divider.insertAdjacentElement('afterend', button)
+    return button
+}
+
+function configureSelectModal(modalElement, buttonConfiguration) {
+
+    modalElement.querySelector('.modal-title').textContent = buttonConfiguration.label
+
+    const select = modalElement.querySelector('select')
+    while (select.firstChild) select.removeChild(select.firstChild)
+
+    for (const configuration of buttonConfiguration.tracks) {
+        const option = document.createElement('option')
+        option.value = configuration.name
+        option.textContent = configuration.name
+        option._track = configuration
+        select.appendChild(option)
+    }
+
+    if (buttonConfiguration.description) {
+        modalElement.querySelector('#igv-widgets-generic-select-modal-footnotes').innerHTML = buttonConfiguration.description
+    }
+}
+
+async function getPathsWithTrackRegistryFile(genomeID, trackRegistryFile) {
+
+    let response
+    try {
+        response = await fetch(trackRegistryFile)
+    } catch (e) {
+        console.error(e)
+    }
+
+    if (!response) {
+        const e = new Error('Error retrieving registry via getPathsWithTrackRegistryFile()')
+        AlertSingleton.present(e.message)
+        throw e
+    }
+
+    const trackRegistry = await response.json()
+    return trackRegistry[genomeID]
+}
+
+export { createTrackWidgetsWithTrackRegistry, updateTrackMenus }

--- a/js/widgets/ui-utils.js
+++ b/js/widgets/ui-utils.js
@@ -1,0 +1,14 @@
+import { createIcon } from './icons.js'
+
+function attachDialogCloseHandlerWithParent(parent, closeHandler) {
+    const container = document.createElement('div')
+    parent.appendChild(container)
+    container.appendChild(createIcon('times'))
+    container.addEventListener('click', e => {
+        e.preventDefault()
+        e.stopPropagation()
+        closeHandler()
+    })
+}
+
+export { attachDialogCloseHandlerWithParent }

--- a/js/widgets/urlModal.js
+++ b/js/widgets/urlModal.js
@@ -1,0 +1,31 @@
+function createURLModal(id, title) {
+
+    const html = `<div id="${id}" class="modal fade" tabindex="-1">
+
+        <div class="modal-dialog modal-lg">
+
+            <div class="modal-content">
+
+                <div class="modal-header">
+                    <div class="modal-title">${title}</div>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+
+                <div class="modal-body">
+                </div>
+
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-sm btn-secondary" data-bs-dismiss="modal">OK</button>
+                </div>
+
+            </div>
+
+        </div>
+
+    </div>`
+
+    return document.createRange().createContextualFragment(html).firstChild
+}
+
+export { createURLModal }

--- a/js/widgets/utils.js
+++ b/js/widgets/utils.js
@@ -1,0 +1,31 @@
+/**
+ * Wire up a Bootstrap-5 modal element so its OK button runs okHandler and dismiss
+ * buttons clean up the file-load widget. The dismiss buttons already carry
+ * data-bs-dismiss="modal", so Bootstrap auto-hides the modal — we just piggy-back
+ * on `hidden.bs.modal` to run widget cleanup and on click to drive OK.
+ */
+function configureModal(fileLoadWidget, modalElement, okHandler) {
+
+    const modal = bootstrap.Modal.getOrCreateInstance(modalElement)
+
+    const doOK = async () => {
+        const result = await okHandler(fileLoadWidget)
+        if (true === result) {
+            fileLoadWidget.dismiss()
+            modal.hide()
+        }
+    }
+
+    // ok button is the second .modal-footer button
+    const ok = modalElement.querySelector('.modal-footer button:nth-child(2)')
+    ok.addEventListener('click', doOK)
+
+    // any dismissal (X, Cancel, ESC, backdrop click) → clean up widget state
+    modalElement.addEventListener('hidden.bs.modal', () => fileLoadWidget.dismiss())
+
+    modalElement.addEventListener('keypress', event => {
+        if ('Enter' === event.key) doOK()
+    })
+}
+
+export { configureModal }

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   "devDependencies": {
     "@rollup/plugin-strip": "^3.0.1",
     "@rollup/plugin-terser": "^1.0.0",
-    "data-modal": "github:igvteam/data-modal#v1.5.0",
     "dotenv": "^17.2.4",
-    "igv-widgets": "github:igvteam/igv-widgets#v1.5.4",
+    "igv-utils": "github:igvteam/igv-utils#v1.7.1",
+    "infinite-table": "github:igvteam/infinite-table#main",
     "juicebox.js": "github:igvteam/juicebox.js#master",
     "rollup": "^4.60.3",
     "rollup-plugin-copy": "^3.4.0"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -21,6 +21,8 @@ export default [
                         {src: 'node_modules/juicebox.js/dist/css/img', dest: 'dist/css/'},
                         {src: 'scripts/embed.html', dest: 'dist/'},
                         {src: 'css/app.css', dest: 'dist/css/'},
+                        {src: 'css/widgets.css', dest: 'dist/css/'},
+                        {src: 'node_modules/infinite-table/css/infinite-table.css', dest: 'dist/css/'},
                         {src: 'img', dest: 'dist/'},
                         {src: 'juiceboxConfig.js', dest: 'dist/'},
 

--- a/scripts/aiden_lab_navbar_additions.html
+++ b/scripts/aiden_lab_navbar_additions.html
@@ -1,9 +1,9 @@
 <!-- Info -->
-<li class="nav-item ml-4">
+<li class="nav-item ms-4">
 
-    <div class="dropdown ml-4 mt-1">
+    <div class="dropdown ms-4 mt-1">
 
-        <button type="button" class="btn btn-outline-light dropdown-toggle" data-toggle="dropdown">
+        <button type="button" class="btn btn-outline-light dropdown-toggle" data-bs-toggle="dropdown">
 
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-info-circle" viewBox="0 0 16 16">
                 <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>

--- a/scripts/generateHtml.js
+++ b/scripts/generateHtml.js
@@ -26,6 +26,10 @@ for (let line of lines) {
         fs.writeSync(fd, '<link rel="stylesheet" href="css/juicebox.css"/>\n', null, 'utf-8');
     }
 
+    else if(line.includes("infinite-table.css")) {
+        fs.writeSync(fd, '<link rel="stylesheet" href="css/infinite-table.css">\n', null, 'utf-8');
+    }
+
     else if (line.includes("@VERSION")) {
         line = line.replace("@VERSION", version);
         fs.writeSync(fd, line + '\n', null, 'utf-8');


### PR DESCRIPTION
## Summary

- Replaces the `igv-widgets` bundle (jQuery + BS4 hairball) with in-tree ports of the three factories juicebox-web actually used — `createSessionWidgets`, `createTrackWidgetsWithTrackRegistry`, `updateTrackMenus` — in vanilla JS targeting Bootstrap 5.
- Swaps the `data-modal` contact-map tables to `infinite-table`, removing the last DataTables/jQuery dep.
- With those gone, the top-level Bootstrap upgrade is finally possible: BS 4.4.1 + jQuery 3.3.1 + Popper out, BS 5.3.8 bundle in. Resolves the four `TODO(jquery-purge)` seams left by #45.

## What's in `js/widgets/`

Faithful port of `igv-widgets` v1.5.4 internals: `sessionWidgets`, `trackWidgets`, `fileLoad`, `fileLoadWidget`, `fileLoadManager`, `sessionFileLoad`, `multipleTrackFileLoad`, `urlModal`, `trackURLModal`, `genericSelectModal`, `encodeTrackDatasourceConfigurator`, `utils`, `dom-utils`, `ui-utils`, `draggable`, `icons`. Translated to plain DOM APIs and BS5 modal markup. Google Drive code paths dropped (juicebox-web never enabled them). `css/widgets.css` carries the file-load-widget and alert-dialog styles previously self-injected by `igv-widgets`' `embedCSS`.

## Dependency churn

- Removed: `igv-widgets`, `data-modal`
- Added: `igv-utils@v1.7.1`, `infinite-table@main`

## Test plan

- [x] `npm run build` succeeds
- [x] First-party source is jQuery-free (no `$(...)` calls; only comment references remain)
- [x] App loads, no console errors, no \"\$ is not defined\" / \"bootstrap is not defined\"
- [x] Top navbar dropdowns open/close (Load Map, Load \"B\" Map, Load Tracks, Share, Session)
- [x] Contact-map modals (Juicebox Archive / ENCODE / 4DN) open via infinite-table, populate, allow single-row selection, load on OK
- [x] Track modals: ENCODE Signals — ChIP/Other open via infinite-table and load tracks on OK
- [x] Track URL modal loads a track from a typed URL
- [x] Session save writes JSON; Session → Load URL restores state
- [x] Alert dialog renders with the expected styling (now from `css/widgets.css`)
- [x] Share modal: shortened URL + QR + embed snippet; COPY closes modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)