### PR TITLE
Fix dead igv.org.app catalog URLs for ENCODE/4DN contact maps

### DIFF
--- a/js/encodeContactMapDatasourceConfig.js
+++ b/js/encodeContactMapDatasourceConfig.js
@@ -1,7 +1,7 @@
 
 const encodeContactMapDatasourceConfiguration =
     {
-        url: 'https://s3.amazonaws.com/igv.org.app/encode/hic/hic.txt',
+        url: 'https://raw.githubusercontent.com/igvteam/igv-data/main/data/encode/hic.txt',
         columns:
             [
                 // 'HREF',

--- a/js/fourdnContactMapDatasourceConfig.js
+++ b/js/fourdnContactMapDatasourceConfig.js
@@ -1,7 +1,7 @@
 
 const fourdnContactMapDatasourceConfiguration =
     {
-            url: 'https://s3.amazonaws.com/igv.org.app/4dn/hic/4dn_hic.txt',
+            url: 'https://raw.githubusercontent.com/igvteam/igv-data/main/data/4dn/4dn_hic.txt',
             columns:
                 [
                         // 'url',

--- a/js/widgets/encodeTrackDatasourceConfigurator.js
+++ b/js/widgets/encodeTrackDatasourceConfigurator.js
@@ -4,7 +4,7 @@
  */
 function encodeTrackDatasourceConfigurator(genomeId, type) {
 
-    const root = 'https://s3.amazonaws.com/igv.org.app/encode/'
+    const root = 'https://raw.githubusercontent.com/igvteam/igv-data/main/data/encode/'
     let url
 
     switch (type) {


### PR DESCRIPTION
## Problem

Opening the ENCODE hosted contact map modal fails with:

```
Access to fetch at 'https://s3.amazonaws.com/igv.org.app/encode/hic/hic.txt'
... blocked by CORS policy: No 'Access-Control-Allow-Origin' header
GET .../encode/hic/hic.txt net::ERR_FAILED 404 (Not Found)
```

The igv team retired the `s3.amazonaws.com/igv.org.app` bucket (it now returns `NoSuchBucket`, which surfaces in the browser as both a 404 and a CORS failure since the error response carries no CORS headers). The catalog files were relocated to the `igvteam/igv-data` GitHub repo, served via `raw.githubusercontent.com` with `access-control-allow-origin: *`.

## Changes

Repoint the three references from the dead bucket to the current host:

| File | New URL/root |
|---|---|
| `js/encodeContactMapDatasourceConfig.js` | `…/igv-data/main/data/encode/hic.txt` |
| `js/fourdnContactMapDatasourceConfig.js` | `…/igv-data/main/data/4dn/4dn_hic.txt` |
| `js/widgets/encodeTrackDatasourceConfigurator.js` | root → `…/igv-data/main/data/encode/` |

The ENCODE `hic.txt` columns are an exact match for the existing config, so no other changes were needed. All target files confirmed reachable (HTTP 200, CORS-enabled).

## Testing

Verified locally — the ENCODE hosted contact map modal now loads correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)