### PR TITLE
Fix CORS failure loading genome list; add backup URL fallback

### DIFF
--- a/js/initializationHelper.js
+++ b/js/initializationHelper.js
@@ -10,9 +10,27 @@ import QRCode from "./qrcode.js";
 import configureContactMapLoaders from "./contactMapLoad.js";
 import {tinyURLShortener} from "./urlShortener.js";
 
+// CORS-enabled mirror of the genome list, used if config.genome is unreachable.
+// Matches the backup URL used by igv.js (genomeUtils.js BACKUP_GENOMES_URL).
+const BACKUP_GENOMES_URL = 'https://raw.githubusercontent.com/igvteam/igv-data/refs/heads/main/genomes/web/genomes.json'
+
 let currentGenomeId
 let genomeDerivedTrackConfigurations
 let shortenURL
+
+async function fetchGenomeList(url) {
+    try {
+        const response = await fetch(url)
+        if (!response.ok) {
+            throw new Error(`HTTP ${ response.status }`)
+        }
+        return await response.json()
+    } catch (error) {
+        console.error(`Error fetching genome list from ${ url }, falling back to backup`, error)
+        const response = await fetch(BACKUP_GENOMES_URL)
+        return await response.json()
+    }
+}
 
 function initializationHelper(container, config) {
 
@@ -89,8 +107,7 @@ function initializationHelper(container, config) {
             currentGenomeId = data
 
             if (config.genome) {
-                const response = await fetch(config.genome)
-                const list = await response.json()
+                const list = await fetchGenomeList(config.genome)
                 genomeDerivedTrackConfigurations = createGenomeDerivedTrackConfigurations(currentGenomeId, list)
             }
 

--- a/js/juiceboxConfig.js
+++ b/js/juiceboxConfig.js
@@ -1,6 +1,6 @@
 export const juiceboxConfig = {
 
-    genome: 'https://igv.org/genomes/genomes.json',
+    genome: 'https://igv.org/genomes/genomes3.json',
 
     mapMenu: {
         id: 'contact-map-datalist',


### PR DESCRIPTION
## Problem

Loading a session failed with:

```
Access to fetch at 'https://igv.org/genomes/genomes.json' from origin
'http://localhost:5173' has been blocked by CORS policy: No
'Access-Control-Allow-Origin' header is present on the requested resource.
...
Uncaught (in promise) TypeError: Failed to fetch
    at genomeChangeListener (initializationHelper.js:92)
```

`juiceboxConfig.js` pointed `genome` at `https://igv.org/genomes/genomes.json`. igv.org serves that **old** file **without** an `Access-Control-Allow-Origin` header, so the browser discards the response (the `200 OK` is real but blocked by CORS) and session restore throws. This affects any origin, not just localhost.

## Fix

- Switch to `https://igv.org/genomes/genomes3.json` — the CORS-enabled (`access-control-allow-origin: *`), current genome list that igv.js itself uses as its `DEFAULT_GENOMES_URL` (`genomeUtils.js`). It's also more up to date than the old file (includes `hs1`/T2T). Same array-of-genome-objects shape, so `createGenomeDerivedTrackConfigurations` is unaffected.
- Add a `fetchGenomeList()` helper that falls back to the CORS-safe `igv-data` GitHub mirror (matching igv.js's `BACKUP_GENOMES_URL`) on any fetch failure, so genome-derived track configs still load if igv.org is unreachable. Previously this was a bare `await fetch(config.genome)` with no error handling.

## Testing

Verified the original session loads without the CORS error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)